### PR TITLE
Fix throttling condor jobs

### DIFF
--- a/python/processingfw/pfwconfig.py
+++ b/python/processingfw/pfwconfig.py
@@ -375,8 +375,9 @@ class PfwConfig(WCL):
     def get_dag_cmd_opts(self):
         """Create dictionary of condor_submit_dag command line options"""
         cmdopts = {}
-        for key in ['max_pre', 'max_post', 'max_jobs', 'max_idle']:
-            (exists, value) = self.search('dagman_' + key)
+        for ending in ['max_pre', 'max_post', 'max_jobs', 'max_idle']:
+            key = 'dagman_' + ending
+            (exists, value) = self.search(key)
             if exists:
                 cmdopts[key] = value
         return cmdopts


### PR DESCRIPTION
WCL entries responsible for throttling condor jobs were ignored due to
their inconsistent naming.  Fixed it.